### PR TITLE
Remove switch rgba

### DIFF
--- a/linux/include/texture_rgba_renderer/texture_rgba_renderer.h
+++ b/linux/include/texture_rgba_renderer/texture_rgba_renderer.h
@@ -39,21 +39,6 @@ G_DEFINE_TYPE(TextureRgba, texture_rgba,
   (G_TYPE_CHECK_INSTANCE_CAST((obj), texture_rgba_get_type(), \
                               TextureRgba))
 
-static inline void switch_rgba(uint8_t* pixels, int len, int height) {
-    uint8_t temp;
-    int byes_per_row = len / height;
-    int width = byes_per_row >> 2;
-    for (int i = 0; i < height; ++i) {
-      int row_idx_base = i * byes_per_row;
-      for (int k = 0; k < width; ++k) {
-        int idx = row_idx_base + k * 4;
-        temp = pixels[idx];
-        pixels[idx] = pixels[idx + 2];
-        pixels[idx + 2] = temp;
-      }
-    }
-}
-
 
 static void texture_rgba_terminate(TextureRgba* self) {
   g_mutex_lock(&self->mutex);

--- a/linux/texture_rgba_renderer_plugin.cc
+++ b/linux/texture_rgba_renderer_plugin.cc
@@ -154,7 +154,6 @@ extern "C" {
         // copy data to the texture.
         auto copied_data = new uint8_t[len];
         memcpy(copied_data, buffer, len); 
-        switch_rgba(copied_data, len, height);
         // It's safe to working on a non reading index
         g_atomic_pointer_set(&self->buffer, copied_data);
         g_atomic_int_set(&self->video_height, height);

--- a/windows/texture_rgba.cpp
+++ b/windows/texture_rgba.cpp
@@ -39,6 +39,23 @@ void TextureRgba::MarkVideoFrameAvailable(
 	}
 }
 
+void TextureRgba::MarkVideoFrameAvailable2(const uint8_t* buffer, const size_t buffer_length, size_t width, size_t height) {
+	if (!buffer  || buffer_length < width * height * 4)
+	{
+		return;
+	}
+	const std::lock_guard<std::mutex> lock(mutex_);
+	int bg_index = fg_index_ ^ 1;
+	buffer_tmp_[bg_index].assign(buffer, buffer + buffer_length);
+	width_[bg_index] = width;
+	height_[bg_index] = height;
+	if (!buff_ready_)
+	{
+		buff_ready_ = true;
+		texture_registrar_->MarkTextureFrameAvailable(texture_id_);
+	}
+}
+
 // This function may be called
 // event texture_registrar_->MarkTextureFrameAvailable(texture_id_); is not called before.
 inline const FlutterDesktopPixelBuffer *TextureRgba::buffer()

--- a/windows/texture_rgba.cpp
+++ b/windows/texture_rgba.cpp
@@ -16,24 +16,6 @@ TextureRgba::~TextureRgba()
 	texture_registrar_->UnregisterTexture(texture_id_);
 }
 
-void TextureRgba::switch_rgba(std::vector<uint8_t> &buffer, size_t height)
-{
-	uint8_t temp;
-	size_t byes_per_row = buffer.size() / height;
-	size_t width = byes_per_row >> 2;
-	for (size_t i = 0; i < height; ++i)
-	{
-		size_t row_idx_base = i * byes_per_row;
-		for (size_t k = 0; k < width; ++k)
-		{
-			size_t idx = row_idx_base + k * 4;
-			temp = buffer[idx];
-			buffer[idx] = buffer[idx + 2];
-			buffer[idx + 2] = temp;
-		}
-	}
-}
-
 void TextureRgba::MarkVideoFrameAvailable(
 	std::vector<uint8_t> &buffer, size_t width, size_t height)
 {
@@ -45,7 +27,6 @@ void TextureRgba::MarkVideoFrameAvailable(
 	// Do not check bellow. Because the data may have paddings per row.
 	// buffer.size() != width * height * 4
 
-	switch_rgba(buffer, height);
 	const std::lock_guard<std::mutex> lock(mutex_);
 	int bg_index = fg_index_ ^ 1;
 	buffer.swap(buffer_tmp_[bg_index]);

--- a/windows/texture_rgba.h
+++ b/windows/texture_rgba.h
@@ -13,6 +13,8 @@ public:
 
 	void MarkVideoFrameAvailable(std::vector<uint8_t>& buffer, size_t width, size_t height);
 
+	void MarkVideoFrameAvailable2(const uint8_t* buffer, size_t buffer_length, size_t width, size_t height);
+
 	int64_t texture_id() const { return texture_id_; };
 
 	const FlutterDesktopPixelBuffer* buffer();

--- a/windows/texture_rgba.h
+++ b/windows/texture_rgba.h
@@ -18,9 +18,6 @@ public:
 	const FlutterDesktopPixelBuffer* buffer();
 
 private:
-	void switch_rgba(std::vector<uint8_t>& buffer, size_t height);
-
-private:
 	FlutterDesktopPixelBuffer flutter_pixel_buffer_{};
 	flutter::TextureRegistrar* texture_registrar_ = nullptr;
 	std::unique_ptr<flutter::TextureVariant> texture_ = nullptr;

--- a/windows/texture_rgba_renderer_plugin_c_api.cpp
+++ b/windows/texture_rgba_renderer_plugin_c_api.cpp
@@ -25,6 +25,5 @@ void FlutterRgbaRendererPluginOnRgba(void *texture_rgba, const uint8_t *buffer, 
     }
     
     TextureRgba *rgba = static_cast<TextureRgba *>(texture_rgba);
-    std::vector<uint8_t> data(buffer, buffer + len);
-    rgba->MarkVideoFrameAvailable(data, width, height);
+    rgba->MarkVideoFrameAvailable2(buffer, len, width, height);
 }


### PR DESCRIPTION
1. Remove `switch_rgba`, convert to target rgba format during yuv to rgb
2. Avoid memory allocation on windows.

## Test
For 1080p, without `switch_rgba`

MarkVideoFrameAvailable:
![9161620478c53fe9ad08b6ca6b8cf91](https://github.com/user-attachments/assets/6a0e5337-b2cd-46b6-bb79-46a76aa24530)

MarkVideoFrameAvailable2:
![778d530cc7b7557b5651a801487394e](https://github.com/user-attachments/assets/60f15ef9-697d-481f-a207-97cfd4eb7e16)

